### PR TITLE
README fixup

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -27,7 +27,7 @@ We don't believe in static, podium-based training. Instead, SuperOrbital courses
 
 We provide a curriculum that covers everything your team needs to go from zero to Kubernetes expert. We tailor each workshop to your team's situation and needs, and we're happy to create custom chapters.
 
-<iframe allow="autoplay; fullscreen" allowfullscreen="true" frameborder="0" src="https://player.vimeo.com/video/497435265"></iframe>
+https://github.com/superorbital/.github/assets/129629/5732c1d5-84bf-4334-ae49-5a093af051db
 
 ### [Core Kubernetes](https://superorbital.io/workshops/core-kubernetes/)
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-![superorbital-logo-white-background](https://github.com/superorbital/.github/assets/129629/3ec86a94-8369-455d-bd4b-eb2574e16904)
+<img src="https://github.com/superorbital/.github/assets/129629/3ec86a94-8369-455d-bd4b-eb2574e16904" width="600" height="auto" alt="SuperOrbital LLC logo (Saturn planet silhouette on a white background)">
 
 ### We transform companies through Kubernetes engineering and training.
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-<img src="https://superorbital.io/img/logo.png" width="600" height="auto">
+![superorbital-logo-white-background](https://github.com/superorbital/.github/assets/129629/3ec86a94-8369-455d-bd4b-eb2574e16904)
 
 ### We transform companies through Kubernetes engineering and training.
 


### PR DESCRIPTION
[View README](https://github.com/superorbital/.github/blob/6b0833e744d3cac4752422c2ed22304f1c69049e/profile/README.md)

* Replace the transparent logo with a solid white background for light and dark theme support.
  * This is using the same image link as before with a defined width. If we use GitHub Markdown, the logo will scale with the browser width like the video image below.
* Replace non-working video iframe with embedded video via GitHub Markdown.
  * This will scale to the width of the browser window, which makes it a bit large, but it also works, which the iframe does not.
* Earlier commit to main (fixed typo): `judgement` --> `judgment`
